### PR TITLE
Fix README: zlib1g-dev is needed to compile lxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following was tested on Ubuntu server 12.04 LTS:
 
 * If you're planning on using feeds, you might want to install libxml:
 
-        apt-get install libxml2-dev libxslt-dev
+        apt-get install libxml2-dev libxslt-dev zlib1g-dev
         pip install lxml
 
 


### PR DESCRIPTION
On Debian Jessie the zlib1g-dev package was needed to compile lxml during the pip install. It seems this might affect Ubuntu 10.04+ too (http://stackoverflow.com/a/17378157/862188)
