### PR TITLE
Add mongo configuration, fixes #40

### DIFF
--- a/Malcom/analytics/analytics.py
+++ b/Malcom/analytics/analytics.py
@@ -102,9 +102,9 @@ class Worker(Thread):
 
 class Analytics(Process):
 
-	def __init__(self, max_workers=4):
+	def __init__(self, max_workers=4, setup={}):
 		super(Analytics, self).__init__()
-		self.data = Model()
+		self.data = Model(setup)
 		self.max_workers = max_workers
 		self.active = False
 		self.active_lock = threading.Lock()

--- a/Malcom/config/malconf.py
+++ b/Malcom/config/malconf.py
@@ -71,6 +71,24 @@ class MalcomSetup(dict):
 			self['YARA_PATH'] = config.get('sniffer', 'yara_path')
 			self['SNIFFER_NETWORK'] = config.getboolean('sniffer', 'network')
 
+		self['DATABASE'] = {'HOSTS': 'localhost', 'PORT': 27017, 'NAME': 'malcom'}
+		if config.has_section('database'):
+			db_params = dict(config.items('database'))
+			if 'hosts' in db_params:
+				self['DATABASE']['HOSTS'] = split(db_params['hosts'], ',')
+			if 'port' in db_params:
+				self['DATABASE']['PORT'] = db_params['port']
+			if 'name' in db_params:
+				self['DATABASE']['NAME'] = db_params['name']
+			if 'username' in db_params:
+				self['DATABASE']['USERNAME'] = db_params['username']
+			if 'password' in db_params:
+				self['DATABASE']['PASSWORD'] = db_params['password']
+			if 'authentication_database' in db_params:
+				self['DATABASE']['SOURCE'] = db_params['authentication_database']
+			if 'replset' in db_params:
+				self['DATABASE']['REPLSET'] = db_params['replset']
+
 		if config.has_section('feeds'):
 			self['ACTIVATED_FEEDS'] = []
 			for feed in config.options('feeds'):

--- a/Malcom/config/malconf.py
+++ b/Malcom/config/malconf.py
@@ -71,8 +71,8 @@ class MalcomSetup(dict):
 			self['YARA_PATH'] = config.get('sniffer', 'yara_path')
 			self['SNIFFER_NETWORK'] = config.getboolean('sniffer', 'network')
 
-		self['DATABASE'] = {'HOSTS': ['localhost'], 'NAME': 'malcom'}
 		if config.has_section('database'):
+			self['DATABASE'] = {}
 			db_params = dict(config.items('database'))
 			if 'hosts' in db_params:
 				self['DATABASE']['HOSTS'] = db_params['hosts'].split( ',')

--- a/Malcom/config/malconf.py
+++ b/Malcom/config/malconf.py
@@ -71,13 +71,11 @@ class MalcomSetup(dict):
 			self['YARA_PATH'] = config.get('sniffer', 'yara_path')
 			self['SNIFFER_NETWORK'] = config.getboolean('sniffer', 'network')
 
-		self['DATABASE'] = {'HOSTS': 'localhost', 'PORT': 27017, 'NAME': 'malcom'}
+		self['DATABASE'] = {'HOSTS': ['localhost'], 'NAME': 'malcom'}
 		if config.has_section('database'):
 			db_params = dict(config.items('database'))
 			if 'hosts' in db_params:
-				self['DATABASE']['HOSTS'] = split(db_params['hosts'], ',')
-			if 'port' in db_params:
-				self['DATABASE']['PORT'] = db_params['port']
+				self['DATABASE']['HOSTS'] = db_params['hosts'].split( ',')
 			if 'name' in db_params:
 				self['DATABASE']['NAME'] = db_params['name']
 			if 'username' in db_params:
@@ -88,6 +86,8 @@ class MalcomSetup(dict):
 				self['DATABASE']['SOURCE'] = db_params['authentication_database']
 			if 'replset' in db_params:
 				self['DATABASE']['REPLSET'] = db_params['replset']
+			if 'read_preferences' in db_params:
+				self['DATABASE']['READ_PREF'] = db_params['read_preferences']
 
 		if config.has_section('feeds'):
 			self['ACTIVATED_FEEDS'] = []

--- a/Malcom/feeds/feed.py
+++ b/Malcom/feeds/feed.py
@@ -142,7 +142,7 @@ class FeedEngine(Process):
 	def __init__(self, configuration):
 		Process.__init__(self)
 		self.configuration = configuration
-		self.model = Model()
+		self.model = Model(self.configuration)
 		self.feeds = {}
 		self.threads = {}
 		self.global_thread = None

--- a/Malcom/model/model.py
+++ b/Malcom/model/model.py
@@ -38,10 +38,11 @@ class Model:
 
 	def __init__(self, setup):
 		read_pref = {'PRIMARY': ReadPreference.PRIMARY, 'PRIMARY_PREFERRED': ReadPreference.PRIMARY_PREFERRED, 'SECONDARY': ReadPreference.SECONDARY, 'SECONDARY_PREFERRED': ReadPreference.SECONDARY_PREFERRED, 'NEAREST': ReadPreference.NEAREST}
-		self._connection = MongoClient(host = setup['DATABASE'].get('HOSTS', 'localhost'), replicaSet = setup['DATABASE'].get('REPLSET', None), read_preference = read_pref[setup['DATABASE'].get('READ_PREF', 'PRIMARY')])
-		self._db = self._connection[setup['DATABASE'].get('NAME', 'malcom')]
-		if 'USERNAME' in setup['DATABASE']:
-			self._db.authenticate(setup['DATABASE']['USERNAME'], password = setup['DATABASE'].get('PASSWORD', None), source = setup['DATABASE'].get('SOURCE', None))
+		db_setup = setup.get('DATABASE', {})
+		self._connection = MongoClient(host = db_setup.get('HOSTS', ['localhost:27017']), replicaSet = db_setup.get('REPLSET', None), read_preference = read_pref[db_setup.get('READ_PREF', 'PRIMARY')])
+		self._db = self._connection[db_setup.get('NAME', 'malcom')]
+		if 'USERNAME' in db_setup:
+			self._db.authenticate(db_setup['USERNAME'], password = db_setup.get('PASSWORD', None), source = db_setup.get('SOURCE', None))
 		self._db.add_son_manipulator(Transform())
 
 		# collections

--- a/Malcom/model/model.py
+++ b/Malcom/model/model.py
@@ -15,7 +15,6 @@ from bson.objectid import ObjectId
 from bson.json_util import dumps as bson_dumps
 from bson.json_util import loads as bson_loads
 
-from __main__ import setup
 from Malcom.auxiliary.toolbox import *
 from Malcom.model.datatypes import Hostname, Url, Ip, As, Evil, DataTypes
 from Malcom.model.user_management import UserManager
@@ -37,7 +36,7 @@ class Transform(SONManipulator):
 
 class Model:
 
-	def __init__(self):
+	def __init__(self, setup):
 		read_pref = {'PRIMARY': ReadPreference.PRIMARY, 'PRIMARY_PREFERRED': ReadPreference.PRIMARY_PREFERRED, 'SECONDARY': ReadPreference.SECONDARY, 'SECONDARY_PREFERRED': ReadPreference.SECONDARY_PREFERRED, 'NEAREST': ReadPreference.NEAREST}
 		self._connection = MongoClient(host = setup['DATABASE'].get('HOSTS', 'localhost'), replicaSet = setup['DATABASE'].get('REPLSET', None), read_preference = read_pref[setup['DATABASE'].get('READ_PREF', 'PRIMARY')])
 		self._db = self._connection[setup['DATABASE'].get('NAME', 'malcom')]
@@ -51,7 +50,7 @@ class Model:
 		self.sniffer_sessions = self._db.sniffer_sessions
 		self.feeds = self._db.feeds
 		self.history = self._db.history
-		self.um = UserManager()
+		self.um = UserManager(setup)
 
 		# create indexes
 		self.rebuild_indexes()

--- a/Malcom/model/user_management.py
+++ b/Malcom/model/user_management.py
@@ -13,7 +13,6 @@ import pymongo.errors
 from passlib.hash import pbkdf2_sha512
 from flask.ext.login import make_secure_token
 
-from __main__ import setup
 from Malcom.auxiliary.toolbox import debug_output
 
 
@@ -33,7 +32,7 @@ class UserTransform(SONManipulator):
 
 class UserManager():
 	"""Class to manage Malcom users"""
-	def __init__(self):
+	def __init__(self, setup):
 		read_pref = {'PRIMARY': ReadPreference.PRIMARY, 'PRIMARY_PREFERRED': ReadPreference.PRIMARY_PREFERRED, 'SECONDARY': ReadPreference.SECONDARY, 'SECONDARY_PREFERRED': ReadPreference.SECONDARY_PREFERRED, 'NEAREST': ReadPreference.NEAREST}
 		self._connection = MongoClient(host = setup['DATABASE'].get('HOSTS', 'localhost'), replicaSet = setup['DATABASE'].get('REPLSET', None), read_preference = read_pref[setup['DATABASE'].get('READ_PREF', 'PRIMARY')])
 		self._db = self._connection[setup['DATABASE'].get('NAME', 'malcom')]

--- a/Malcom/model/user_management.py
+++ b/Malcom/model/user_management.py
@@ -34,10 +34,11 @@ class UserManager():
 	"""Class to manage Malcom users"""
 	def __init__(self, setup):
 		read_pref = {'PRIMARY': ReadPreference.PRIMARY, 'PRIMARY_PREFERRED': ReadPreference.PRIMARY_PREFERRED, 'SECONDARY': ReadPreference.SECONDARY, 'SECONDARY_PREFERRED': ReadPreference.SECONDARY_PREFERRED, 'NEAREST': ReadPreference.NEAREST}
-		self._connection = MongoClient(host = setup['DATABASE'].get('HOSTS', 'localhost'), replicaSet = setup['DATABASE'].get('REPLSET', None), read_preference = read_pref[setup['DATABASE'].get('READ_PREF', 'PRIMARY')])
-		self._db = self._connection[setup['DATABASE'].get('NAME', 'malcom')]
-		if 'USERNAME' in setup['DATABASE']:
-			self._db.authenticate(setup['DATABASE']['USERNAME'], password = setup['DATABASE'].get('PASSWORD', None), source = setup['DATABASE'].get('SOURCE', None))
+		db_setup = setup.get('DATABASE', {})
+		self._connection = MongoClient(host = db_setup.get('HOSTS', 'localhost'), replicaSet = db_setup.get('REPLSET', None), read_preference = read_pref[db_setup.get('READ_PREF', 'PRIMARY')])
+		self._db = self._connection[db_setup.get('NAME', 'malcom')]
+		if 'USERNAME' in db_setup:
+			self._db.authenticate(db_setup['USERNAME'], password = db_setup.get('PASSWORD', None), source = db_setup.get('SOURCE', None))
 
 		self.users = self._db.users
 		self.users.ensure_index('username', unique=True)

--- a/Malcom/networking/netsniffer.py
+++ b/Malcom/networking/netsniffer.py
@@ -53,7 +53,7 @@ class SnifferEngine(object):
 
 		self.sessions = {}
 
-		self.model = Model()
+		self.model = Model(self.setup)
 		self.db_lock = threading.Lock()
 
 		self.messenger = SnifferMessenger()

--- a/Malcom/web/api.py
+++ b/Malcom/web/api.py
@@ -11,7 +11,6 @@ import werkzeug
 from werkzeug.datastructures import FileStorage
 from flask.ext.login import LoginManager, login_user, login_required, logout_user, current_user
 from Malcom.auxiliary.toolbox import *
-from Malcom.web.webserver import Model, UserManager
 from flask.ext.login import current_user
 from webserver import app
 
@@ -69,7 +68,7 @@ class Neighbors(Resource):
             else:
                 query[key] = {"$in" : request.args.getlist(key)}
 
-        data = Model.find_neighbors(query, include_original=True)
+        data = g.Model.find_neighbors(query, include_original=True)
         return data
 
 class Evil(Resource):
@@ -90,7 +89,7 @@ class Evil(Resource):
             if key not in ['depth']:
                 query[key] = request.args.getlist(key)
 
-        data = Model.multi_graph_find(query, {'key':'tags', 'value': 'evil'}, depth=depth)
+        data = g.Model.multi_graph_find(query, {'key':'tags', 'value': 'evil'}, depth=depth)
         return data
 
 class QueryAPI(Resource):
@@ -118,16 +117,16 @@ class QueryAPI(Resource):
                             else:
                                     query[key] = request.args[key]
         if query:    
-            Model.add_to_history(query.get('value'))
+            g.Model.add_to_history(query.get('value'))
         data = {}
         chrono_query = datetime.datetime.utcnow()
 
         print "Query: ", query
         print "Regex:", regex
         if regex:
-            elts = list(Model.elements.find(query, skip=page*per_page, limit=per_page, sort=[('date_created', pymongo.DESCENDING)]).hint([('date_created', -1), ('value', 1)]))
+            elts = list(g.Model.elements.find(query, skip=page*per_page, limit=per_page, sort=[('date_created', pymongo.DESCENDING)]).hint([('date_created', -1), ('value', 1)]))
         else:
-            elts = list(Model.elements.find(query, skip=page*per_page, limit=per_page, sort=[('date_created', pymongo.DESCENDING)]))
+            elts = list(g.Model.elements.find(query, skip=page*per_page, limit=per_page, sort=[('date_created', pymongo.DESCENDING)]))
 
         chrono_query = datetime.datetime.utcnow() - chrono_query
 
@@ -147,7 +146,7 @@ class QueryAPI(Resource):
 
         chrono_count = datetime.datetime.utcnow()
         if not regex:
-            data['total_results'] = Model.find(query).count()
+            data['total_results'] = g.Model.find(query).count()
         else:
             data['total_results'] = "many"
         chrono_count = datetime.datetime.utcnow() - chrono_count
@@ -173,7 +172,7 @@ class DatasetAPI(Resource):
             except InvalidId:
                 return {'error': 'You must specify an ID'}, 400
 
-            result = Model.remove_by_id(_id)
+            result = g.Model.remove_by_id(_id)
             return result
 
         if action == 'add':
@@ -214,7 +213,7 @@ class SnifferSessionDelete(Resource):
 
         if result == "removed":  # session successfully stopped
             current_user.remove_sniffer_session(session_id)
-            UserManager.save_user(current_user)
+            g.UserManager.save_user(current_user)
             return {'status': "Sniffer session %s has been deleted" % session_id, 'success': 1}
 
 
@@ -223,7 +222,7 @@ class SnifferSessionPcap(Resource):
     def get(self, session_id):
         result = g.messenger.send_recieve('sniffpcap', 'sniffer-commands', {'session_id': session_id})
         print result
-        session = Model.get_sniffer_session(session_id)
+        session = g.Model.get_sniffer_session(session_id)
         if 'pcap_filename' in session:
             return send_from_directory(g.config['SNIFFER_DIR'],session['pcap_filename'] , mimetype='application/vnd.tcpdump.pcap', as_attachment=True, attachment_filename='malcom_capture_'+session_id+'.pcap')
 
@@ -295,7 +294,7 @@ class SnifferSessionData(Resource):
         if _all:
             return session_info
 
-        result = Model.find({'_id': {'$in': [ObjectId(i) for i in session_info['node_list']]}})
+        result = g.Model.find({'_id': {'$in': [ObjectId(i) for i in session_info['node_list']]}})
 
         if elements:
             return {"node_list" : list(result)}

--- a/Malcom/web/webserver.py
+++ b/Malcom/web/webserver.py
@@ -49,10 +49,6 @@ app.secret_key = os.urandom(24)
 app.debug = True
 lm = LoginManager()
 
-Model = ModelClass()
-UserManager = UserManagerClass()
-
-
 # This enables the server to be ran behind a reverse-proxy
 # Make sure you have an nginx configuraiton similar to this
 
@@ -167,6 +163,10 @@ def before_request():
 	# make configuration and analytics engine available to views
 	g.config = app.config
 	g.messenger = app.config['MESSENGER']
+	if not 'Model' in g:
+		g.Model = ModelClass(app.config)
+	if not 'UserManager' in g:
+		g.UserManager = UserManagerClass(app.config)
 
 	if g.config['AUTH']:
 		g.user = current_user
@@ -178,19 +178,19 @@ def before_request():
 @lm.token_loader
 def load_token(token):
 	print "Load token"
-	u = UserManager.get_user(token=token)
+	u = g.UserManager.get_user(token=token)
 	if u:
 		u.last_activity = datetime.datetime.utcnow()
-		u = UserManager.save_user(u)
+		u = g.UserManager.save_user(u)
 	return u
 
 @lm.user_loader
 def load_user(username):
 	print "Load user"
-	u = UserManager.get_user(username=username)
+	u = g.UserManager.get_user(username=username)
 	if u:
 		u.last_activity = datetime.datetime.utcnow()
-		u = UserManager.save_user(u)
+		u = g.UserManager.save_user(u)
 	return u
 
 @lm.request_loader
@@ -198,22 +198,22 @@ def load_user_from_request(request):
 	print "Load user from request"
 	api_key = request.headers.get("X-Malcom-API-Key")
 	if not app.config['AUTH']:
-		u=UserManager.get_default_user()
+		u=g.UserManager.get_default_user()
 		return u
 	if api_key:
 		print "Getting user for API key %s" % api_key
-		u = UserManager.get_user(api_key=api_key)
+		u = g.UserManager.get_user(api_key=api_key)
 		if u:
 			u.api_last_activity = datetime.datetime.utcnow()
 			u.api_request_count += 1
-			u = UserManager.save_user(u)
+			u = g.UserManager.save_user(u)
 
 @app.route("/logout")
 @login_required
 def logout():
 	if 'token' in current_user:
 		del current_user['token']
-	UserManager.save_user(current_user)
+	g.UserManager.save_user(current_user)
 	logout_user()
 	return redirect(url_for('login'))
 
@@ -231,13 +231,13 @@ def login():
 		print "Login attempt for %s (rememberme: %s)" % (username, rememberme)
 
 		# get user w/ username
-		user = UserManager.get_user(username=username)
+		user = g.UserManager.get_user(username=username)
 
 		# check its password
 		if user and user.check_password(password):
 			print "Success!"
 			user.get_auth_token()
-			UserManager.save_user(user)
+			g.UserManager.save_user(user)
 			login_user(user, remember=rememberme)
 			return redirect(request.args.get("next") or url_for("index"))
 		else:
@@ -275,7 +275,7 @@ def account_settings():
 				return redirect(url_for('account_settings'))
 
 			current_user.reset_password(new)
-			UserManager.save_user(current_user)
+			g.UserManager.save_user(current_user)
 			flash('Password changed successfully!', 'success')
 			return redirect(url_for('account_settings'))
 
@@ -342,14 +342,14 @@ def search(term=""):
 	if request.method == 'POST':
 		field = 'value'
 		query = [{field: r} for r in request.form['bulk-text'].split('\r\n') if r != '']
-		result_set = Model.find({'$or': query})
+		result_set = g.Model.find({'$or': query})
 	else:
 		query = request.args.get('query', False)
 		field = request.args.get('field', 'value')
 		if not bool(request.args.get('strict', False)):
-			result_set = Model.find({field: query})
+			result_set = g.Model.find({field: query})
 		else:
-			result_set = Model.find({field: re.compile(re.escape(query), re.IGNORECASE)})
+			result_set = g.Model.find({field: re.compile(re.escape(query), re.IGNORECASE)})
 
 	# user has specified an empty query
 	if query == "":
@@ -358,11 +358,11 @@ def search(term=""):
 
 	# user did not specify a query
 	if query == False:
-		return render_template('search.html', history=Model.get_history())
+		return render_template('search.html', history=g.Model.get_history())
 
 	if bool(request.args.get('log', False)):
 			print "Adding to history"
-			Model.add_to_history(query)
+			g.Model.add_to_history(query)
 
 	# query passed tests, process the result set
 	base_elts = []
@@ -380,12 +380,12 @@ def search(term=""):
 	if len(base_elts) == 0:
 		if not bool(request.args.get('log', False)):
 			flash('"{}" was not found. Use the checkbox above to add it to the database'.format(query))
-			return render_template('search.html', term=query, history=Model.get_history())
+			return render_template('search.html', term=query, history=g.Model.get_history())
 		else:
-			new = Model.add_text([query], tags=['search'])
+			new = g.Model.add_text([query], tags=['search'])
 			flash('"{}" was not found. It was added to the database (ID: {})'.format(query, new['_id']))
 			# or do the redirection here
-			return render_template('search.html', term=query, history=Model.get_history())
+			return render_template('search.html', term=query, history=g.Model.get_history())
 
 	return find_related(field, query, base_elts, base_ids, evil_elts)
 
@@ -395,7 +395,7 @@ def find_related(field, query, base_elts, base_ids, evil_elts):
 
 	first_degree = {}
 
-	data = Model.find_neighbors({ '_id' : {'$in': base_ids}})
+	data = g.Model.find_neighbors({ '_id' : {'$in': base_ids}})
 	nodes = data['nodes']
 	edges = data['edges']
 
@@ -456,7 +456,7 @@ def dataset():
 @login_required
 @user_is_admin
 def clear():
-	Model.clear_db()
+	g.Model.clear_db()
 	return redirect(url_for('dataset'))
 
 @app.route('/dataset/csv')
@@ -481,7 +481,7 @@ def dataset_csv():
 			filename.append('all')
 
 	filename = "-".join(filename)
-	results = Model.find(query).sort('date_created', -1)
+	results = g.Model.find(query).sort('date_created', -1)
 
 	if results.count() == 0:
 		flash("You're about to download an empty .csv",'warning')
@@ -531,9 +531,9 @@ def add_data():
 	for e in elements:
 		if ";" in e:
 			elt, tag = e.split(';')
-			Model.add_text([elt], tag.split(','))
+			g.Model.add_text([elt], tag.split(','))
 		else:
-			Model.add_text([e])
+			g.Model.add_text([e])
 
 	return redirect(url_for('dataset'))
 
@@ -589,7 +589,7 @@ def sniffer():
 
 		# associate sniffer session with current user
 		current_user.add_sniffer_session(session_id)
-		UserManager.save_user(current_user)
+		g.UserManager.save_user(current_user)
 		debug_output("Added session %s for user %s" % (session_id, current_user.username))
 
 		# if requested, start sniffing right away
@@ -670,7 +670,7 @@ class MalcomWeb(Process):
 		lm.init_app(app)
 		lm.login_view = 'login'
 		lm.session_protection = 'strong'
-		lm.anonymous_user = UserManager.get_default_user
+		lm.anonymous_user = UserManagerClass(self.setup).get_default_user
 
 		for key in self.setup:
 			app.config[key] = self.setup[key]

--- a/Malcom/web/websockets.py
+++ b/Malcom/web/websockets.py
@@ -4,7 +4,7 @@ import gevent
 from bson.objectid import ObjectId
 from bson.json_util import dumps, loads
 
-from Malcom.web.webserver import Model, login_required
+from Malcom.web.webserver import login_required
 from Malcom.auxiliary.toolbox import *
 
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,86 @@ The following was tested on Ubuntu server 14.04 LTS:
 * Launch the webserver from the `malcom` directory using `./malcom.py`. Check `./malcom.py --help` for listen interface and ports.
   * For starters, you can copy the `malcom.conf.example` file to `malcom.conf` and run `./malcom.py -c malcom.conf`
 
+### Configuration
+
+#### Database
+
+By default, Malcom will try to connect to a local mongodb instance and crete its own database, named malcom. If its ok for you, you don't need to read this nd should pass to the next step. Otherwise, you need to edit the `database` section of your `malcom.conf` file.
+
+##### Set an other name for your Malcom database
+
+By default, Malcom will use a database named `malcom`. If you don't want this, just edit the `malcom.conf` file and set the `name` directive from the `database` section to your liking.
+
+        [database]
+        ...
+        name = my_malcom_database
+        ...
+
+##### Remote database(s)
+
+By default, Malcom will try to connect to localhost but your database may be on another server. Just set the `hosts` directive. You may use hostnames or IPv4/v6 addresses (just keep in mind to enclose your IPv6 addresses between '[' and ']', like **[::1]**).
+
+If your mongod is a standalone database my.mongo.server, just set:
+
+        [database]
+        ...
+        hosts = my.mongo.server
+        ...
+
+You may also listen on some non-standard port. Just add it after the name/address of your server, separated with a "**:**"
+
+        [database]
+        ...
+        hosts = localhost:27008
+        ...
+
+And if your using a ReplicaSet regrouping my.mongo1.server and my.mongo2.server, just set:
+
+        [database]
+        ...
+        hosts = my.mongo1.server,my.mongo2.server
+        ...
+
+##### Use authentication
+
+You may have configured your mongod instances to enforce authenticated connections. In that case, you have to set the username the driver will have to use to connect to your mongod instance. To do this, just add a `username` directive to the `database` section in the `malcom.conf` file. You may also set the password with the `password` directive. If the user does not have a password, just ignore (i.e. comment) the `password` directive.
+
+        [database]
+        ...
+        username = my_user
+        password = change_me
+        ...
+
+If the user is not linked to the malcom database but to another one (for example the `admin` database for a admin user), you will have to set the `authentication_database` directive with the name of that database.
+
+        [database]
+        ...
+        authentication_database = some_other_database
+        ...
+
+##### Case of a replica set
+
+When using a replica set, you may need to ensure you are connected to the right one. For that, just add the `replset` directive to force the mongo driver to check the name of the replicaset
+
+        [database]
+        ...
+        replset = my_mongo_replica
+        ...
+
+By default, Malcom will try to connect to the primary node of th replica set. You may need/want to change that. In order to change that behaviour, just set the `read_preference` directive. See [the mongo documentation](http://docs.mongodb.org/manual/core/read-preference/) for more information.
+
+        [database]
+        ...
+        read_preference = NEAREST
+        ...
+
+Supported read preferences are:
+* PRIMARY
+* PRIMARY\_PREFERRED
+* SECONDARY
+* SECONDARY\_PREFERRED
+* NEAREST
+
 ### Docker instance
 
 The quickest way to get you started is to pull the Docker image from the [public docker repo](https://registry.hub.docker.com/u/tomchop/malcom/). **To pull the automatic Docker build for the latest GitHub commit**, use `tomchop/malcom-automatic` instead of `tomchop/malcom`.

--- a/malcom.conf.example
+++ b/malcom.conf.example
@@ -25,12 +25,40 @@ yara_path = yara
 
 # databases can be configured here
 
-[db_local]
-name = Local
-type = db
-host = localhost
-port = 27017
+[database]
+# The name of the Malcom database
+# default: malcom
+name = malcom
 
+# Comma-separated list of server names or addresses hosting the database. Ports may be defined by host
+# example: my_server1,my_server2:27018,182.168.0.10[,...]
+# If you have any IPv6 addresses, they have to enclosed in '[' and ']' characters (ex: [::1])
+# default: localhost
+host = localhost
+
+# ReplicaSet name (optionnal)
+# If set, the pymongo driver will check if the hosts above are really part of the named replicaSet when connecting to them
+# default: None
+#replset = my_replicaset
+
+# Read preference when connected to a replicaset
+# Read http://docs.mongodb.org/manual/core/read-preference/ for more information
+# Values are PRIMARY, PRIMARY_PREFERRED, SECONDARY, SECONDARY_PREFERRED, NEAREST
+# default: PRIMARY
+# read_preference = PRIMARY
+
+# Username to log in the database, if authentication is needed by the database
+# default: None
+#username = some_user
+
+# Password for the above user
+# default: None
+#password = change_me
+
+# Database used to authenticate the above user
+# If not set, it will use the current database
+# default: None
+#authentication_database = malcom
 
 [feeds]
 # You can comment / uncomment feeds

--- a/malcom.py
+++ b/malcom.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 	if setup['ANALYTICS']:
 		sys.stderr.write("[+] Starting analytics engine...\n")
 		from Malcom.analytics.analytics import Analytics
-		setup.analytics_engine = Analytics(setup['MAX_WORKERS'])
+		setup.analytics_engine = Analytics(setup['MAX_WORKERS'], setup)
 		setup.analytics_engine.start()
 		
 	if setup['WEB']:


### PR DESCRIPTION
Hi,

This should do the work to fix #40. I wasn't able to test all the cases (mainly the replicaset part) but I was able to change the database, connect to a remote mongo instance and authenticate against the database.

I'm quite new to python so I'm not sure that the 
```python
from __main__ import setup
```
is the right way to propagate the configuration. I figured it was the easiest way allowing reading the configuration without having to refactor a lot more of code.

I also updated the `malcom.conf.exemple` and the `README.md` files accordingly to the changes.